### PR TITLE
Removing windows and mac tests from test workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.8]
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest]
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
- Windows and MacOS tests will no longer be run on every PR/commit. Instead we will run Ubuntu tests only.
- Tests on all three platforms will still run as part of the build-and-release workflow.